### PR TITLE
Oracle#isPmdKnownBroken is true

### DIFF
--- a/src/main/java/nl/b3p/loader/jdbc/OracleJdbcConverter.java
+++ b/src/main/java/nl/b3p/loader/jdbc/OracleJdbcConverter.java
@@ -144,7 +144,7 @@ public class OracleJdbcConverter extends GeometryJdbcConverter {
 
     @Override
     public boolean isPmdKnownBroken() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
kennelijk is dit nodig als er een kolom via een trigger wordt gevuld zoals in topnl parser van de brmo