### PR TITLE
[oracle] return null als input geometrie null is

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,7 +513,6 @@
     </reporting>
     <profiles>
         <profile>
-            <!-- actief voor oa. Jenkins builds -->
             <id>oracle</id>
             <properties />
             <build>
@@ -526,7 +525,6 @@
                                 <database.properties.file>oracle.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                             </systemPropertyVariables>
-                            <!-- <excludedGroups>nl.b3p.brmo.test.util.database.OracleDriverBasedFailures</excludedGroups>-->
                             <useFile>false</useFile>
                             <argLine>${failsafeArgLine}</argLine>
                         </configuration>
@@ -535,7 +533,6 @@
             </build>
         </profile>
         <profile>
-            <!-- actief voor oa. Travis-CI builds -->
             <id>postgresql</id>
             <build>
                 <plugins>
@@ -547,7 +544,6 @@
                                 <database.properties.file>postgis.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                             </systemPropertyVariables>
-                            <!-- <excludedGroups>nl.b3p.brmo.test.util.database.PostgreSQLDriverBasedFailures</excludedGroups>-->
                             <excludes>
                                 <exclude>**/*OracleIntegrationTest.java</exclude>
                             </excludes>
@@ -559,7 +555,6 @@
             </build>
         </profile>
         <profile>
-            <!-- actief voor oa. AppVeyor builds -->
             <id>mssql</id>
             <build>
                 <plugins>
@@ -571,7 +566,6 @@
                                 <database.properties.file>sqlserver.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                             </systemPropertyVariables>
-                            <!-- <excludedGroups>nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures</excludedGroups> -->
                             <excludes>
                                 <exclude>**/*OracleIntegrationTest.java</exclude>
                             </excludes>
@@ -603,7 +597,6 @@
                                 <database.properties.file>hsqldb.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                             </systemPropertyVariables>
-                            <!-- <excludedGroups>nl.b3p.brmo.test.util.database.HSQLDBDriverBasedFailures</excludedGroups> -->
                             <excludes>
                                 <exclude>**/*OracleIntegrationTest.java</exclude>
                             </excludes>

--- a/src/main/java/nl/b3p/loader/jdbc/OracleJdbcConverter.java
+++ b/src/main/java/nl/b3p/loader/jdbc/OracleJdbcConverter.java
@@ -60,7 +60,7 @@ public class OracleJdbcConverter extends GeometryJdbcConverter {
     @Override
     public Object convertToNativeGeometryObject(Geometry g, int srid) throws SQLException, ParseException {
         if(g == null){
-            return gc.toSDO(null, srid);
+            return g;
         }
         String param = g.toText();
         // return param;

--- a/src/test/java/nl/b3p/loader/jdbc/NullGeomOracleIntegrationTest.java
+++ b/src/test/java/nl/b3p/loader/jdbc/NullGeomOracleIntegrationTest.java
@@ -48,10 +48,9 @@ public class NullGeomOracleIntegrationTest extends AbstractDatabaseIntegrationTe
      *
      * @throws Exception if any
      */
-    @DisplayName("test null geometrie XML")
-    @ParameterizedTest(name = "#{index} - waarde: {0}")
+    @ParameterizedTest(name = "#{index} - waarde: \"{0}\"")
     @NullAndEmptySource
-    @ValueSource(strings = {"", " ", "   "})
+    @ValueSource(strings = {" ", "   "})
     public void testNullGeomXML(String testVal) throws Exception {
         if (isOracle) {
             Connection connection = DriverManager.getConnection(
@@ -63,10 +62,7 @@ public class NullGeomOracleIntegrationTest extends AbstractDatabaseIntegrationTe
             OracleJdbcConverter c = new OracleJdbcConverter(oc);
 
             OracleStruct s = (OracleStruct) c.convertToNativeGeometryObject(testVal);
-            assertEquals("MDSYS.SDO_GEOMETRY", s.getSQLTypeName(), "verwacht een sdo geometry");
-            for (Object o : s.getAttributes()) {
-                assertNull(o, "verwacht 'null'");
-            }
+            assertNull(s, "verwacht een null sdo geometry");
         }
     }
 }

--- a/src/test/java/nl/b3p/loader/jdbc/RoundTripIntegrationTest.java
+++ b/src/test/java/nl/b3p/loader/jdbc/RoundTripIntegrationTest.java
@@ -20,6 +20,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * test of de converters round-trip safe zijn, dus JTS-input naar native naar JTS-output moet gelijk blijven.
+ * 
+ *  gebruik bijvoorbeeld: 
+ *  {@code mvn -Dit.test=RoundTripIntegrationTest verify -Poracle -Dtest.onlyITs=true}
+ *  om deze test te draaien.
+ *  
  * @author mark
  */
 public class RoundTripIntegrationTest extends AbstractDatabaseIntegrationTest {


### PR DESCRIPTION
Voorkomt aanmaken van ongeldige SDO geom (`empty` geometry) door een `null` value

uit: https://docs.oracle.com/cd/E11882_01/appdev.112/e11830/sdo_objgeom.htm#SPATL1107
> operations can return a null value, that is, an empty geometry

en

> A null value (empty geometry) as an input parameter to a geometry function



close #14

NB. relevante GeoTools code: 

https://github.com/geotools/geotools/blob/136a56f446b9086bf27318b072d0135a469500ab/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/GeometryConverter.java#L146-L225

en

https://github.com/ianturton/geotools/blob/d8791674b5bc0c0c5512f0838aacaced7d3b1040/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java#L612-L621
