### PR TITLE
maak unwrappen van tomcat org.apache.tomcat.dbcp.dbcp.DelegatingConnection mogelijk

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -1,10 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-   <suppress>
-      <notes><![CDATA[
-      file name: postgis-jdbc-2.3.0.jar
-      ]]></notes>
-      <packageUrl regex="true">^pkg:maven/net\.postgis/postgis\-jdbc@.*$</packageUrl>
-      <cpe>cpe:/a:postgis_project:postgis</cpe>
-   </suppress>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+             Negeer meldingen mbt postgis-jdbc jar, hebben allemaal betrekking op de database engine ]]>
+        </notes>
+        <gav regex="true">^net\.postgis:postgis-jdbc:.*$</gav>
+        <cpe>cpe:/a:postgis:postgis</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+             Negeer meldingen mbt tomcat-api-7.0.96.jar omdat we geen tomcat mee leveren en deze
+                     alleen voor bepaalde deployments geldt.            ]]>
+        </notes>
+        <filePath regex="true">.*\btomcat-dbcp-7\.0\.96\.jar</filePath>
+        <cve>CVE-2016-5425</cve>
+        <cve>CVE-2017-6056</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: tomcat-util-7.0.96.jar   ]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat/tomcat\-util@.*$</packageUrl>
+        <cpe>cpe:/a:apache:tomcat</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: tomcat-api-7.0.96.jar   ]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat/tomcat\-api@.*$</packageUrl>
+        <cpe>cpe:/a:apache:tomcat</cpe>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-dbcp</artifactId>
+            <version>7.0.96</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.tomcat</artifactId>
+                    <groupId>tomcat-util</groupId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>nl.b3p</groupId>
             <artifactId>brmo-test-util</artifactId>
             <version>1.6.3p1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,26 @@
             <version>${geotools.version}</version>
         </dependency>
         <dependency>
+            <!-- transitieve dep van gt-jdbc-oracle, kan verwijderd worden bij/na upgrade van geotools >22.0 -->
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+            <exclusions>
+                <!--
+                workaround voor https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-6379
+                deze gt-referencing dependency mag weg na upgrade naar geotools to 22.1
+                -->
+                <exclusion>
+                    <groupId>javax</groupId>
+                    <artifactId>javaee-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.axis</groupId>
+                    <artifactId>axis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>commons-dbutils</groupId>
             <artifactId>commons-dbutils</artifactId>
             <version>${dbutils.version}</version>

--- a/src/main/java/nl/b3p/loader/jdbc/OracleConnectionUnwrapper.java
+++ b/src/main/java/nl/b3p/loader/jdbc/OracleConnectionUnwrapper.java
@@ -42,11 +42,20 @@ public class OracleConnectionUnwrapper {
         OracleConnection oc;
 
         if(c.isWrapperFor(OracleConnection.class)) {
+            LOG.trace("Unwrap Connection voor OracleConnection");
             oc = c.unwrap(OracleConnection.class);
         } else if(mdC instanceof OracleConnection) {
+            LOG.trace("Cast MetaData Connection naar OracleConnection");
             oc = (OracleConnection)mdC;
+        } else if (mdC instanceof org.apache.tomcat.dbcp.dbcp.PoolableConnection) {
+            LOG.trace("Cast naar OracleConnection via cast naar tomcat DelegatingConnection");
+            oc = (OracleConnection) ((org.apache.tomcat.dbcp.dbcp.DelegatingConnection) mdC).getDelegate();
         } else {
-            throw new SQLException("Kan connectie niet unwrappen naar OracleConnection!");
+            throw new SQLException(
+                    "Kan connectie niet unwrappen naar OracleConnection van meta connectie: "
+                            + mdC.getClass().getName()
+                            + ", connection: " + c.getClass().getName()
+            );
         }
 
         return oc;


### PR DESCRIPTION
org.apache.tomcat.dbcp.dbcp.DelegatingConnection wordt gebruikt in Maven testcases icm tomcat-maven-plugin