### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.onlyITs>false</test.onlyITs>
         <oracle.jdbc.version>19.6.0.0</oracle.jdbc.version>
-        <geotools.version>23.0</geotools.version>
+        <geotools.version>23.1</geotools.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.3</jaxb.impl.version>
         <sqlserver.jtds.version>1.3.1</sqlserver.jtds.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>nl.b3p</groupId>
             <artifactId>brmo-test-util</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2-rc1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Dependency updates: 
- Bump GeoTools: 23.0 ➜ 23.1
- Bump nl.b3p:brmo-test-util: 2.0.1 ➜ 2.0.2-rc1
- Bump commons-io:commons-io: 2.6 ➜ 2.7