### PR TITLE
verwerkt oracle API change van GeoTools 24 upgrade

### DIFF
--- a/src/test/java/nl/b3p/loader/jdbc/NullGeomOracleIntegrationTest.java
+++ b/src/test/java/nl/b3p/loader/jdbc/NullGeomOracleIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import nl.b3p.AbstractDatabaseIntegrationTest;
 import oracle.jdbc.OracleConnection;
+import oracle.jdbc.OracleStruct;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -74,7 +75,7 @@ public class NullGeomOracleIntegrationTest extends AbstractDatabaseIntegrationTe
             OracleConnection oc = OracleConnectionUnwrapper.unwrap(connection);
             OracleJdbcConverter c = new OracleJdbcConverter(oc);
 
-            Struct s = (Struct) c.convertToNativeGeometryObject(this.testVal);
+            OracleStruct s = (OracleStruct) c.convertToNativeGeometryObject(this.testVal);
             assertEquals("verwacht een sdo geometry", "MDSYS.SDO_GEOMETRY", s.getSQLTypeName());
             for (Object o : s.getAttributes()) {
                 assertNull("verwacht 'null'", o);


### PR DESCRIPTION
should fix:

```
15:04:43  [ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 4.142 s <<< FAILURE! - in nl.b3p.loader.jdbc.NullGeomOracleIntegrationTest
15:04:43  [ERROR] nl.b3p.loader.jdbc.NullGeomOracleIntegrationTest.testNullGeomXML[0: testwaarde: {0}]  Time elapsed: 3.745 s  <<< ERROR!
15:04:43  java.lang.NoSuchMethodError: org.geotools.data.oracle.sdo.GeometryConverter.toSDO(Lorg/locationtech/jts/geom/Geometry;I)Loracle/sql/STRUCT;
15:04:43  	at nl.b3p.loader.jdbc.OracleJdbcConverter.convertToNativeGeometryObject(OracleJdbcConverter.java:63)
15:04:43  	at nl.b3p.loader.jdbc.OracleJdbcConverter.convertToNativeGeometryObject(OracleJdbcConverter.java:74)
15:04:43  	at nl.b3p.loader.jdbc.GeometryJdbcConverter.convertToNativeGeometryObject(GeometryJdbcConverter.java:147)
15:04:43  	at nl.b3p.loader.jdbc.NullGeomOracleIntegrationTest.testNullGeomXML(NullGeomOracleIntegrationTest.java:77)
```