### PR TITLE
verwijder vreemde convolutie uit code en delegeer direct naar geotools

### DIFF
--- a/src/main/java/nl/b3p/jdbc/util/converter/GeometryJdbcConverter.java
+++ b/src/main/java/nl/b3p/jdbc/util/converter/GeometryJdbcConverter.java
@@ -169,7 +169,7 @@ public abstract class GeometryJdbcConverter {
 
     public Object convertToNativeGeometryObject(String param) throws ParseException, SQLException {
         Geometry o = null;
-        if (param != null) {
+        if (param != null && param.trim().length() > 0) {
             o = wkt.read(param);
         }
         return convertToNativeGeometryObject(o);

--- a/src/main/java/nl/b3p/jdbc/util/converter/OracleJdbcConverter.java
+++ b/src/main/java/nl/b3p/jdbc/util/converter/OracleJdbcConverter.java
@@ -28,6 +28,7 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
 import java.sql.SQLException;
+import java.sql.Struct;
 
 /**
  *
@@ -60,14 +61,11 @@ public class OracleJdbcConverter extends GeometryJdbcConverter {
     
     @Override
     public Object convertToNativeGeometryObject(Geometry g, int srid) throws SQLException, ParseException {
-        if(g == null){
-            return g;
+        if (g == null) {
+            return null;
+        } else {
+            return gc.toSDO(g, srid);
         }
-        String param = g.toText();
-        // return param;
-        WKTReader reader = new WKTReader(gf);
-        Geometry geom = param == null || param.trim().length() == 0 ? null : reader.read(param);
-        return gc.toSDO(geom, srid);
     }
     
     @Override

--- a/src/test/java/nl/b3p/jdbc/util/converter/NullGeomOracleIntegrationTest.java
+++ b/src/test/java/nl/b3p/jdbc/util/converter/NullGeomOracleIntegrationTest.java
@@ -60,7 +60,7 @@ public class NullGeomOracleIntegrationTest extends AbstractDatabaseIntegrationTe
      *
      * @throws Exception if any
      */
-    @ParameterizedTest(name = "#{index} - waarde: \"{0}\"")
+    @ParameterizedTest(name = "#{index} - waarde: `{0}`")
     @NullAndEmptySource
     @ValueSource(strings = {" ", "   "})
     public void testNullGeomXML(String testVal) throws Exception {


### PR DESCRIPTION
NB, GeoTools geeft een lege Struct terug voor een `null` geometrie; dat is onjuist - zo'n geometrie geeft problemen tijdens bouwen van spatial indexen en materialized views.