### PR TITLE
Upgrade PostGIS JDBC van 2.5.1 naar 2021.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.b3p</groupId>
     <artifactId>jdbc-util</artifactId>
-    <version>10.3-SNAPSHOT</version>
+    <version>11.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JDBC Util</name>
     <description>JDBC utilities: Converter for geometries and other useful things</description>
@@ -27,7 +27,7 @@
         <test.junit-jupiter.version>5.8.2</test.junit-jupiter.version>
         <sqlserver.jdbc.version>9.5.0.jre11-preview</sqlserver.jdbc.version>
         <postgresql.jdbc.version>42.3.1</postgresql.jdbc.version>
-        <postgresql.postgis-jdbc.version>2.5.1</postgresql.postgis-jdbc.version>
+        <postgresql.postgis-jdbc.version>2021.1.0</postgresql.postgis-jdbc.version>
         <dbutils.version>1.7</dbutils.version>
         <maven.surefire.version>3.0.0-M5</maven.surefire.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/nl/b3p/jdbc/util/converter/PostgisJdbcConverter.java
+++ b/src/main/java/nl/b3p/jdbc/util/converter/PostgisJdbcConverter.java
@@ -18,10 +18,10 @@
  */
 package nl.b3p.jdbc.util.converter;
 
+import net.postgis.jdbc.PGgeometry;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import java.sql.SQLException;
-import org.postgis.PGgeometry;
 
 /**
  *


### PR DESCRIPTION
dit is een backwards incompatible update omdat de package namen zijn aangepast