### PR TITLE
Voorkom ORA-00932: inconsistent datatypes: expected MDSYS.SDO_GEOMETRY got CHAR bij null geometrie

### DIFF
--- a/src/main/java/nl/b3p/jdbc/util/converter/OracleJdbcConverter.java
+++ b/src/main/java/nl/b3p/jdbc/util/converter/OracleJdbcConverter.java
@@ -60,12 +60,13 @@ public class OracleJdbcConverter extends GeometryJdbcConverter {
     }
     
     @Override
-    public Object convertToNativeGeometryObject(Geometry g, int srid) throws SQLException, ParseException {
-        if (g == null) {
-            return null;
-        } else {
-            return gc.toSDO(g, srid);
-        }
+    public Object convertToNativeGeometryObject(Geometry g, int srid) throws SQLException {
+        // geen (Object)null geven, dat levert in veel gevallen een
+        // java.sql.SQLException: ORA-00932: inconsistent datatypes: expected MDSYS.SDO_GEOMETRY got CHAR
+        // if (null ==g){
+        //     return ((OracleStruct)null);
+        // }
+        return gc.toSDO(g, srid);
     }
     
     @Override

--- a/src/test/java/nl/b3p/jdbc/util/converter/NullGeomOracleIntegrationTest.java
+++ b/src/test/java/nl/b3p/jdbc/util/converter/NullGeomOracleIntegrationTest.java
@@ -74,7 +74,9 @@ public class NullGeomOracleIntegrationTest extends AbstractDatabaseIntegrationTe
             OracleJdbcConverter c = new OracleJdbcConverter(oc);
 
             OracleStruct s = (OracleStruct) c.convertToNativeGeometryObject(testVal);
-            assertNull(s, "verwacht een null object");
+            for (Object o : s.getAttributes()) {
+                assertNull(o, "verwacht een null object");
+            }
         }
     }
 }


### PR DESCRIPTION
Geen `(Object) null` geven, dat levert in veel gevallen een `java.sql.SQLException: ORA-00932: inconsistent datatypes: expected MDSYS.SDO_GEOMETRY got CHAR`