### PR TITLE
Bump GeoTools van 28.2 naar 29-RC1

### DIFF
--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -83,7 +83,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    if: ${{ github.ref == 'refs/heads/master' && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) }}
+    if: ${{ (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/geotools')) && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) }}
     steps:
       - uses: actions/checkout@v3
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.onlyITs>false</test.onlyITs>
         <oracle.jdbc.version>21.9.0.0</oracle.jdbc.version>
-        <geotools.version>28.2</geotools.version>
+        <geotools.version>29-RC1</geotools.version>
         <jts.version>1.19.0</jts.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.3</jaxb.impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.b3p</groupId>
     <artifactId>jdbc-util</artifactId>
-    <version>13.4-SNAPSHOT</version>
+    <version>14.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JDBC Util</name>
     <description>JDBC utilities: Converter for geometries and other useful things</description>


### PR DESCRIPTION
blokkeert: https://github.com/B3Partners/brmo/pull/1742

zie: https://github.com/geotools/geotools/releases/tag/29-RC1
