### PR TITLE
Bump GeoTools van 30.2 naar 31.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.b3p</groupId>
     <artifactId>jdbc-util</artifactId>
-    <version>16.3-SNAPSHOT</version>
+    <version>17.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JDBC Util</name>
     <description>JDBC utilities: Converter for geometries and other useful things</description>
@@ -57,7 +57,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.onlyITs>false</test.onlyITs>
         <oracle.jdbc.version>23.3.0.23.09</oracle.jdbc.version>
-        <geotools.version>30.2</geotools.version>
+        <geotools.version>31-RC</geotools.version>
         <jts.version>1.19.0</jts.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.3</jaxb.impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.onlyITs>false</test.onlyITs>
         <oracle.jdbc.version>23.3.0.23.09</oracle.jdbc.version>
-        <geotools.version>31-RC</geotools.version>
+        <geotools.version>31.0</geotools.version>
         <jts.version>1.19.0</jts.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.3</jaxb.impl.version>


### PR DESCRIPTION
- [x] Bump GeoTools van 30.2 naar [31-RC](https://github.com/geotools/geotools/releases/tag/31-RC)
- [x] Bump GeoTools van 31-RC naar [31.0](https://github.com/geotools/geotools/releases/tag/31.0)

blocks https://github.com/B3Partners/brmo/pull/2058