### PR TITLE
Revert "Bump org.apache.maven.plugins:maven-scm-publish-plugin from 3.2.1 to 3.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
Reverts B3Partners/jdbc-util#600

this is causing a problem publishing the site:
```
[INFO] Checking out the pub tree from scm:git:ssh://git@github.com/b3partners/jdbc-util.git into /home/mark/dev/projects/jdbc-util/target/checkout/target/scmpublish-checkout
[INFO] Executing: /bin/sh -c cd '/home/mark/dev/projects/jdbc-util/target/checkout/target' && 'git' 'clone' '--branch' 'gh-pages' 'ssh://git:********@github.com/b3partners/jdbc-util.git' 'scmpublish-checkout'
[INFO] Working directory: /home/mark/dev/projects/jdbc-util/target/checkout/target
[ERROR] Failed to check out from SCM: The git-clone command failed. Cloning into 'scmpublish-checkout'...
git:********@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.270 s (Wall Clock)
[INFO] Finished at: 2024-08-06T09:40:04+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-scm-publish-plugin:3.3.0:publish-scm (scm-publish) on project jdbc-util: Failed to check out from SCM: The git-clone command failed. Cloning into 'scmpublish-checkout'...
[ERROR] git:********@github.com: Permission denied (publickey).
[ERROR] fatal: Could not read from remote repository.
[ERROR] 
[ERROR] Please make sure you have the correct access rights
[ERROR] and the repository exists.
[ERROR] 


```