### PR TITLE
Bump GeoTools van 31.3 naar 32.0

### DIFF
--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -92,7 +92,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    if: ${{ (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/geotools-30.1')) && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) }}
+    if: ${{ (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/geotools_32')) && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.b3p</groupId>
     <artifactId>jdbc-util</artifactId>
-    <version>17.4-SNAPSHOT</version>
+    <version>18.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JDBC Util</name>
     <description>JDBC utilities: Converter for geometries and other useful things</description>
@@ -56,7 +56,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.onlyITs>false</test.onlyITs>
         <oracle.jdbc.version>23.5.0.24.07</oracle.jdbc.version>
-        <geotools.version>31.3</geotools.version>
+        <geotools.version>32-SNAPSHOT</geotools.version>
         <jts.version>1.20.0</jts.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.3</jaxb.impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <test.onlyITs>false</test.onlyITs>
         <oracle.jdbc.version>23.5.0.24.07</oracle.jdbc.version>
-        <geotools.version>32-SNAPSHOT</geotools.version>
+        <geotools.version>32.0</geotools.version>
         <jts.version>1.20.0</jts.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.3</jaxb.impl.version>


### PR DESCRIPTION
en bump naar versie 18

- [x] Bump GeoTools van 31.3 naar 32-SNAPSHOT
- [ ] Bump GeoTools van 32-SNAPSHOT naar 32-RC
- [x] Bump GeoTools van 32-RC naar 32.0

zie ook [BRMO-371](https://b3partners.atlassian.net/browse/BRMO-371)

[BRMO-371]: https://b3partners.atlassian.net/browse/BRMO-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ