### PR TITLE
Bump tomcat-dbcp versie van 9.0.106 naar 9.0.108

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   update_release_draft:

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
             <!-- kan gebruikt worden in de OracleConnectionUnwrapper -->
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-dbcp</artifactId>
-            <version>9.0.106</version>
+            <version>9.0.108</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
fixes:
- https://github.com/B3Partners/jdbc-util/security/code-scanning/47
- https://github.com/B3Partners/jdbc-util/security/code-scanning/46
- https://github.com/B3Partners/jdbc-util/security/code-scanning/45